### PR TITLE
CSE-1763 deactivate default limit of 250 records in product export

### DIFF
--- a/modules/asign/8select/application/controllers/admin/eightselect_admin_export_do.php
+++ b/modules/asign/8select/application/controllers/admin/eightselect_admin_export_do.php
@@ -20,6 +20,11 @@ class eightselect_admin_export_do extends DynExportBase
     public $sClassMain = "eightselect_admin_export_main";
 
     /**
+     * define max. number of records to export in one go
+     */
+    public $_iExportPerTick = 1000000;
+
+    /**
      * Current class template name.
      *
      * @var string
@@ -28,6 +33,7 @@ class eightselect_admin_export_do extends DynExportBase
 
     /** @var array */
     private $_aParent = [];
+
 
     /**
      * Prepares export
@@ -212,8 +218,6 @@ class eightselect_admin_export_do extends DynExportBase
         $_GET[$sType] = true;
         $_GET['iStart'] = 0;
         $_GET['refresh'] = 0;
-
-        $this->_iExportPerTick = 1000000;
 
         $this->start();
         $this->run();


### PR DESCRIPTION
**Jira Issue**

https://8select.atlassian.net/browse/CSE-1763

**Summary**

Even after [initial bugfix](https://asigngmbh.atlassian.net/projects/SEL/issues/SEL-38) of the problem (only 250 lines exported in product feed), the problem still occurred in some cases.
In this PR, a working solution suggested by one of our customers was applied:
* instead of setting `$_iExportPerTick` in function `_exportCron()` of class `eightselect_admin_export_do`, ´define it as public static variable of the class

<!--
You can assign a team-member to review the PR.
If you are confident that no critical system breaks you can merge without a review.
-->
**Checklist**

- [x] PR title is prefixed with Jira Issue Id - e.g. CSE-42
- [x] Add feature / bug label
- [ ] Unit tests for new / changed logic are passing OR no logic changes were made
